### PR TITLE
Fixed drawing rectangle

### DIFF
--- a/st7789_base.py
+++ b/st7789_base.py
@@ -224,7 +224,7 @@ class ST7789_base:
     # w and h are width/height in pixels.
     def rect(self,x,y,w,h,color,fill=False):
         if fill:
-            self.set_window(x,y,x+w-1,y+1-w)
+            self.set_window(x,y,x+w-1,y+w-1)
             if w*h > 256:
                 buf = color*w
                 for i in range(h): self.write(None, buf)


### PR DESCRIPTION
* old code i.e. can't draw filled rectangle across the entire display with a resolution of 320×240 px - now rectangles are always draw well

* old code broke functionality drawing filled rectangles and upscaled texts on displays with ILI934x  controllers - now driver is fully compatible with this controllers too